### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/DbProcessor.ts
+++ b/DbProcessor.ts
@@ -4,7 +4,7 @@ import * as FS              from "fs";
 import * as Path            from "path";
 import * as mkdirp          from "mkdirp";
 import * as QueryString     from "querystring";
-import * as Uuid            from "node-uuid";
+import * as Uuid            from "uuid";
 
 import {IDbProcessor}       from "./IDbProcessor";
 import {DbCommand}       from "./DbCommand";

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "dependencies": {
     "http-status-codes": "^1.0.5",
     "mkdirp": "^0.5.1",
-    "node-uuid": "^1.4.7",
-    "rimraf": "^2.5.1"
+    "rimraf": "^2.5.1",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "assert": "^1.3.0",

--- a/typings/node-uuid/node-uuid-cjs.d.ts
+++ b/typings/node-uuid/node-uuid-cjs.d.ts
@@ -9,7 +9,7 @@
  * Expose as CommonJS module
  * For use in node environment or browser environment (using webpack or other module loaders)
  */
-declare module "node-uuid" {
+declare module "uuid" {
     var uuid: __NodeUUID.UUID;
     export = uuid;
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.